### PR TITLE
Add web admin portal for module configuration

### DIFF
--- a/MMM-modadmin.js
+++ b/MMM-modadmin.js
@@ -1,1 +1,14 @@
+Module.register("MMM-ModAdmin", {
+  defaults: {
+    adminPort: 8081
+  },
 
+  start() {
+    this.sendSocketNotification("INIT", this.config);
+  },
+
+  getDom() {
+    // This module intentionally renders nothing on the mirror
+    return document.createElement("div");
+  }
+});

--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
-# MMM-modadmin
-MMM module admin portal
+# MMM-ModAdmin
+
+A MagicMirror² module that exposes a web-based admin interface for managing other modules. It renders nothing on the mirror itself; instead it hosts a small web application where you can inspect installed modules and edit their configuration from a browser.
+
+The project follows the structure and style of [MMM-Chores](https://github.com/PierreGode/MMM-Chores).
+
+## Installation
+
+1. Clone this repository into your `MagicMirror/modules` folder.
+2. Add the module to your `config.js`:
+
+```js
+{
+  module: "MMM-ModAdmin",
+  config: {
+    adminPort: 8081
+  }
+}
+```
+
+3. Start MagicMirror and open `http://<mirror-ip>:8081` in a browser to access the admin portal.
+
+From the portal you can:
+- See all modules installed in the `modules` directory
+- View and edit configuration for each module
+- Add new configuration options by editing the JSON for a module
+
+Changes are written back to `config/config.js`.

--- a/node_helper.js
+++ b/node_helper.js
@@ -1,1 +1,64 @@
+const NodeHelper = require("node_helper");
+const express = require("express");
+const bodyParser = require("body-parser");
+const Log = require("logger");
+const fs = require("fs");
+const path = require("path");
 
+module.exports = NodeHelper.create({
+  start() {
+    this.configData = {};
+    this.configPath = path.resolve(__dirname, "..", "..", "config", "config.js");
+    this.modulesDir = path.resolve(__dirname, "..");
+  },
+
+  socketNotificationReceived(notification, payload) {
+    if (notification === "INIT") {
+      this.setupServer(payload);
+    }
+  },
+
+  setupServer(config) {
+    const port = config.adminPort || 8081;
+    const app = express();
+    app.use(bodyParser.json());
+    app.use(express.static(path.join(__dirname, "public")));
+
+    this.readConfig();
+
+    app.get("/api/modules", (req, res) => {
+      fs.readdir(this.modulesDir, { withFileTypes: true }, (err, files) => {
+        if (err) return res.status(500).json({ error: err.message });
+        const mods = files.filter(f => f.isDirectory()).map(f => f.name);
+        res.json(mods);
+      });
+    });
+
+    app.get("/api/config", (req, res) => {
+      res.json(this.configData);
+    });
+
+    app.put("/api/config", (req, res) => {
+      this.configData = req.body;
+      const content = "module.exports = " + JSON.stringify(this.configData, null, 2) + ";\n";
+      fs.writeFile(this.configPath, content, err => {
+        if (err) return res.status(500).json({ error: err.message });
+        res.json({ success: true });
+      });
+    });
+
+    app.listen(port, () => {
+      Log.log(`MMM-ModAdmin server listening on port ${port}`);
+    });
+  },
+
+  readConfig() {
+    try {
+      delete require.cache[require.resolve(this.configPath)];
+      this.configData = require(this.configPath);
+    } catch (err) {
+      Log.error("MMM-ModAdmin: could not load config.js", err);
+      this.configData = {};
+    }
+  }
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "mmm-modadmin",
+  "version": "0.1.0",
+  "description": "MagicMirror² module for web-based module administration.",
+  "main": "MMM-modadmin.js",
+  "scripts": {},
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "express": "^4.18.2",
+    "body-parser": "^1.20.2"
+  }
+}

--- a/public/admin.css
+++ b/public/admin.css
@@ -1,0 +1,25 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
+
+body {
+  font-family: 'Inter', sans-serif;
+  background: #f5f7fa;
+  color: #212529;
+  padding: 1rem;
+}
+
+.module-card {
+  background: #fff;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+
+textarea {
+  width: 100%;
+  height: 120px;
+}
+
+button {
+  margin-top: 0.5rem;
+}

--- a/public/admin.html
+++ b/public/admin.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>MagicMirror Module Admin</title>
+  <link rel="stylesheet" href="admin.css" />
+</head>
+<body>
+  <h1>Module Admin</h1>
+  <div id="modules"></div>
+  <script src="admin.js"></script>
+</body>
+</html>

--- a/public/admin.js
+++ b/public/admin.js
@@ -1,1 +1,43 @@
+async function loadModules() {
+  const modules = await fetch('/api/modules').then(r => r.json());
+  const config = await fetch('/api/config').then(r => r.json());
+  const container = document.getElementById('modules');
 
+  const moduleMap = {};
+  (config.modules || []).forEach(m => { moduleMap[m.module] = m; });
+
+  modules.forEach(name => {
+    const card = document.createElement('div');
+    card.className = 'module-card';
+    const title = document.createElement('h2');
+    title.textContent = name;
+    card.appendChild(title);
+
+    const textarea = document.createElement('textarea');
+    const conf = moduleMap[name] ? moduleMap[name].config || {} : {};
+    textarea.value = JSON.stringify(conf, null, 2);
+    card.appendChild(textarea);
+
+    const btn = document.createElement('button');
+    btn.textContent = 'Save';
+    btn.addEventListener('click', async () => {
+      const newConf = JSON.parse(textarea.value || '{}');
+      if (moduleMap[name]) {
+        moduleMap[name].config = newConf;
+      } else {
+        config.modules = config.modules || [];
+        config.modules.push({ module: name, config: newConf });
+      }
+      await fetch('/api/config', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(config)
+      });
+    });
+    card.appendChild(btn);
+
+    container.appendChild(card);
+  });
+}
+
+loadModules();


### PR DESCRIPTION
## Summary
- add MMM-ModAdmin module skeleton that renders nothing on the mirror and starts helper
- implement node helper with Express server exposing config and module APIs
- ship minimal admin webapp for editing module configuration

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b4ad350cfc83248e49c481ed111855