### PR TITLE
Set default admin port to 5007

### DIFF
--- a/MMM-modadmin.js
+++ b/MMM-modadmin.js
@@ -1,6 +1,6 @@
 Module.register("MMM-ModAdmin", {
   defaults: {
-    adminPort: 8081
+    adminPort: 5007
   },
 
   start() {

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ The project follows the structure and style of [MMM-Chores](https://github.com/P
 {
   module: "MMM-ModAdmin",
   config: {
-    adminPort: 8081
+    adminPort: 5007
   }
 }
 ```
 
-3. Start MagicMirror and open `http://<mirror-ip>:8081` in a browser to access the admin portal.
+3. Start MagicMirror and open `http://<mirror-ip>:5007` in a browser to access the admin portal.
 
 From the portal you can:
 - See all modules installed in the `modules` directory

--- a/node_helper.js
+++ b/node_helper.js
@@ -19,7 +19,7 @@ module.exports = NodeHelper.create({
   },
 
   setupServer(config) {
-    const port = config.adminPort || 8081;
+    const port = config.adminPort || 5007;
     const app = express();
     app.use(bodyParser.json());
     app.use(express.static(path.join(__dirname, "public")));


### PR DESCRIPTION
## Summary
- change default admin port to 5007 for server and module configuration
- update documentation to reflect new port

## Testing
- `npm test` *(fails: Missing script "test" )*


------
https://chatgpt.com/codex/tasks/task_e_68b4b0ec876c8324a82e646d56c78950