### PR TITLE
Serve admin page at root and bind server to all interfaces

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -24,6 +24,10 @@ module.exports = NodeHelper.create({
     app.use(bodyParser.json());
     app.use(express.static(path.join(__dirname, "public")));
 
+    app.get("/", (req, res) => {
+      res.sendFile(path.join(__dirname, "public", "admin.html"));
+    });
+
     this.readConfig();
 
     app.get("/api/modules", (req, res) => {
@@ -47,7 +51,7 @@ module.exports = NodeHelper.create({
       });
     });
 
-    app.listen(port, () => {
+    app.listen(port, "0.0.0.0", () => {
       Log.log(`MMM-ModAdmin server listening on port ${port}`);
     });
   },


### PR DESCRIPTION
## Summary
- Serve the admin interface from `/` instead of requiring `/admin.html`
- Bind Express server to `0.0.0.0` for wider accessibility

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b4b2cd4d90832490a48008208cbb01