### PR TITLE
docs: clarify module config placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,18 @@ The project follows the structure and style of [MMM-Chores](https://github.com/P
 ## Installation
 
 1. Clone this repository into your `MagicMirror/modules` folder.
-2. Add the module to your `config.js`:
+2. Add the module to your `config.js` within the `modules` array:
 
 ```js
-{
-  module: "MMM-ModAdmin",
-  config: {
-    adminPort: 5007
-  }
-}
+modules: [
+  {
+    module: "MMM-ModAdmin",
+    config: {
+      adminPort: 5007
+    }
+  },
+  // other modules
+]
 ```
 
 3. Start MagicMirror and open `http://<mirror-ip>:5007` in a browser to access the admin portal.


### PR DESCRIPTION
## Summary
- clarify how to insert MMM-ModAdmin into the `modules` array of MagicMirror config

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b4c529de48832491f68d56cbe3e08d