### PR TITLE
Add config backup with retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,6 @@ From the portal you can:
 - View and edit configuration for each module
 - Add new configuration options by editing the JSON for a module
 
-Changes are written back to `config/config.js`.
+Changes are written back to `config/config.js`. Before each save a timestamped
+backup of the previous `config.js` is stored in the `config` directory. Only the
+three most recent backups are kept.


### PR DESCRIPTION
## Summary
- backup config.js before saving new config
- keep only the three most recent backups
- document config backup behaviour

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b4cabf0fa88324b393f339cd1e248e