### PR TITLE
Fix module configuration example in README and config file saving

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -44,7 +44,8 @@ module.exports = NodeHelper.create({
 
     app.put("/api/config", (req, res) => {
       this.configData = req.body;
-      const content = "module.exports = " + JSON.stringify(this.configData, null, 2) + ";\n";
+      const json = JSON.stringify(this.configData, null, 2);
+      const content = `let config = ${json};\nif (typeof module !== "undefined") {\n  module.exports = config;\n}\n`;
       this.backupConfig();
       fs.writeFile(this.configPath, content, err => {
         if (err) return res.status(500).json({ error: err.message });


### PR DESCRIPTION
## Summary
- Write full MagicMirror config wrapper when saving config.js

## Testing
- `node --check node_helper.js`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b52451d83883248a35f8ce89debe4e