### PR TITLE
Add modal editor and fix config saving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/node_helper.js
+++ b/node_helper.js
@@ -8,7 +8,12 @@ const path = require("path");
 module.exports = NodeHelper.create({
   start() {
     this.configData = {};
-    this.configPath = path.resolve(__dirname, "..", "..", "config", "config.js");
+    const candidates = [
+      path.resolve(__dirname, "..", "..", "config", "config.js"),
+      path.resolve(__dirname, "..", "..", "..", "config", "config.js"),
+      path.resolve(process.cwd(), "config", "config.js")
+    ];
+    this.configPath = candidates.find(p => fs.existsSync(p)) || candidates[0];
     this.modulesDir = path.resolve(__dirname, "..");
   },
 
@@ -49,6 +54,7 @@ module.exports = NodeHelper.create({
       this.backupConfig();
       fs.writeFile(this.configPath, content, err => {
         if (err) return res.status(500).json({ error: err.message });
+        this.readConfig();
         res.json({ success: true });
       });
     });

--- a/public/admin.css
+++ b/public/admin.css
@@ -23,3 +23,48 @@ textarea {
 button {
   margin-top: 0.5rem;
 }
+
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal.hidden {
+  display: none;
+}
+
+.modal-content {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 4px;
+  width: 300px;
+  max-height: 90%;
+  overflow-y: auto;
+}
+
+.field-row {
+  display: flex;
+  margin-bottom: 0.5rem;
+}
+
+.field-row input {
+  flex: 1;
+}
+
+.field-row input + input {
+  margin-left: 0.5rem;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}

--- a/public/admin.html
+++ b/public/admin.html
@@ -8,6 +8,17 @@
 <body>
   <h1>Module Admin</h1>
   <div id="modules"></div>
+  <div id="editModal" class="modal hidden">
+    <div class="modal-content">
+      <h2 id="modalTitle"></h2>
+      <div id="formFields"></div>
+      <div class="modal-actions">
+        <button id="addField">Add Setting</button>
+        <button id="saveModule">Save</button>
+        <button id="closeModal">Cancel</button>
+      </div>
+    </div>
+  </div>
   <script src="admin.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replace inline JSON editing with modal form per module
- Style and script a popup dialog to edit module settings
- Improve config.js detection and ensure updates reload the config

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b52997f584832488d0f2e9ef949230