### PR TITLE
feat: add theme toggle with glass UI

### DIFF
--- a/public/admin.css
+++ b/public/admin.css
@@ -1,35 +1,118 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
 
+:root {
+  --bg-grad: linear-gradient(135deg, #dfe9f3, #ffffff);
+  --bg: #f5f7fa;
+  --text: #212529;
+  --hero-start: #4e74ff;
+  --hero-end: #6f99ff;
+  --card-bg: rgba(255,255,255,0.6);
+  --field-bg: #fff;
+  --shadow: 0 10px 25px rgba(0,0,0,.1);
+  --list-hover: rgba(0,0,0,.03);
+  --border: rgba(255,255,255,0.4);
+  --blur: 10px;
+}
+
+[data-theme="dark"] {
+  --bg-grad: linear-gradient(135deg, #232526, #414345);
+  --bg: #121212;
+  --text: #e9ecef;
+  --hero-start: #343a40;
+  --hero-end: #495057;
+  --card-bg: rgba(30,30,30,0.6);
+  --field-bg: #c4c4c4;
+  --shadow: 0 10px 25px rgba(0,0,0,.4);
+  --list-hover: rgba(255,255,255,.03);
+  --border: rgba(255,255,255,0.1);
+  --blur: 10px;
+}
+
+/* Global */
 body {
+  background: var(--bg-grad);
+  color: var(--text);
   font-family: 'Inter', sans-serif;
-  background: #f5f7fa;
-  color: #212529;
-  padding: 1rem;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+h1, h2 {
+  font-weight: 600;
+}
+
+/* Hero */
+.hero {
+  background: linear-gradient(135deg, var(--hero-start), var(--hero-end));
+  color: #fff;
+  border-radius: 1rem;
+  padding: 1.5rem 2rem;
+  box-shadow: 0 12px 32px rgba(0,0,0,.15);
+  backdrop-filter: blur(calc(var(--blur) / 2));
+  margin-bottom: 2rem;
+  margin-top: 3rem;
+}
+
+/* Theme toggle */
+.top-controls {
+  position: absolute;
+  top: 30px;
+  right: 22px;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.btn-icon {
+  width: 34px;
+  height: 34px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  background: var(--card-bg);
+  backdrop-filter: blur(var(--blur));
+  box-shadow: var(--shadow);
+  cursor: pointer;
+}
+
+/* Cards */
+.card-shadow {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(var(--blur));
 }
 
 .module-card {
-  background: #fff;
-  border-radius: 4px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
   padding: 1rem;
   margin-bottom: 1rem;
 }
 
-textarea {
-  width: 100%;
-  height: 120px;
+/* Input fields */
+.form-control,
+.form-select {
+  background: var(--field-bg);
+  color: #000;
+  border-color: var(--border);
+  border-radius: 0.5rem;
 }
 
-button {
-  margin-top: 0.5rem;
+[data-theme="dark"] .form-control,
+[data-theme="dark"] .form-select {
+  color: #000;
 }
 
+/* Modal */
 .modal {
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  inset: 0;
   background: rgba(0, 0, 0, 0.5);
   display: flex;
   align-items: center;
@@ -41,14 +124,13 @@ button {
 }
 
 .modal-content {
-  background: #fff;
-  padding: 1rem;
-  border-radius: 4px;
   width: 300px;
   max-height: 90%;
   overflow-y: auto;
+  padding: 1rem;
 }
 
+/* Field rows */
 .field-row {
   display: flex;
   margin-bottom: 0.5rem;
@@ -67,4 +149,13 @@ button {
   justify-content: flex-end;
   gap: 0.5rem;
   margin-top: 1rem;
+}
+
+textarea {
+  width: 100%;
+  height: 120px;
+}
+
+button {
+  margin-top: 0.5rem;
 }

--- a/public/admin.html
+++ b/public/admin.html
@@ -1,15 +1,20 @@
 <!DOCTYPE html>
-<html>
+<html data-theme="light">
 <head>
   <meta charset="utf-8" />
   <title>MagicMirror Module Admin</title>
   <link rel="stylesheet" href="admin.css" />
 </head>
 <body>
-  <h1>Module Admin</h1>
+  <div class="top-controls">
+    <button id="themeToggle" class="btn-icon">🌓</button>
+  </div>
+  <div class="hero">
+    <h1>Module Admin</h1>
+  </div>
   <div id="modules"></div>
   <div id="editModal" class="modal hidden">
-    <div class="modal-content">
+    <div class="modal-content card-shadow">
       <h2 id="modalTitle"></h2>
       <div id="formFields"></div>
       <div class="modal-actions">

--- a/public/admin.js
+++ b/public/admin.js
@@ -2,6 +2,20 @@ let config;
 let moduleMap = {};
 let currentModule = null;
 
+const root = document.documentElement;
+const themeToggle = document.getElementById('themeToggle');
+const savedTheme = localStorage.getItem('theme');
+if (savedTheme) {
+  root.setAttribute('data-theme', savedTheme);
+}
+if (themeToggle) {
+  themeToggle.addEventListener('click', () => {
+    const newTheme = root.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+    root.setAttribute('data-theme', newTheme);
+    localStorage.setItem('theme', newTheme);
+  });
+}
+
 function createFieldRow(key = '', value = '', allowKey = false) {
   const row = document.createElement('div');
   row.className = 'field-row';
@@ -50,7 +64,7 @@ async function loadModules() {
 
   modules.forEach(name => {
     const card = document.createElement('div');
-    card.className = 'module-card';
+    card.className = 'module-card card-shadow';
     const title = document.createElement('h2');
     title.textContent = name;
     card.appendChild(title);


### PR DESCRIPTION
## Summary
- add light/dark theme toggle using CSS variables
- style admin panel with glass effect cards and rounded corners

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b599ed62388324856103101998584e