### PR TITLE
feat: enhance admin interface with translation and settings

### DIFF
--- a/public/admin.css
+++ b/public/admin.css
@@ -124,7 +124,8 @@ h1, h2 {
 }
 
 .modal-content {
-  width: 300px;
+  width: 90%;
+  max-width: 600px;
   max-height: 90%;
   overflow-y: auto;
   padding: 1rem;
@@ -158,4 +159,35 @@ textarea {
 
 button {
   margin-top: 0.5rem;
+}
+
+/* Language select */
+.language-select {
+  width: 60px;
+  font-weight: 600;
+  font-size: 0.8rem;
+  padding: 2px 6px;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  background: var(--card-bg);
+  backdrop-filter: blur(var(--blur));
+  box-shadow: var(--shadow);
+  color: var(--text);
+}
+
+/* Responsive modules grid */
+#modules {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1rem;
+}
+
+@media (max-width: 600px) {
+  .top-controls {
+    top: 10px;
+    right: 10px;
+  }
+  .hero {
+    margin-top: 2rem;
+  }
 }

--- a/public/admin.html
+++ b/public/admin.html
@@ -2,15 +2,21 @@
 <html data-theme="light">
 <head>
   <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>MagicMirror Module Admin</title>
   <link rel="stylesheet" href="admin.css" />
 </head>
 <body>
   <div class="top-controls">
-    <button id="themeToggle" class="btn-icon">🌓</button>
+    <button id="themeToggle" class="btn-icon" title="Toggle theme">🌓</button>
+    <select id="languageSelect" class="language-select">
+      <option value="en">EN</option>
+      <option value="sv">SV</option>
+    </select>
+    <button id="settingsBtn" class="btn-icon" title="Settings">⚙️</button>
   </div>
   <div class="hero">
-    <h1>Module Admin</h1>
+    <h1 data-i18n="title">Module Admin</h1>
   </div>
   <div id="modules"></div>
   <div id="editModal" class="modal hidden">
@@ -18,12 +24,21 @@
       <h2 id="modalTitle"></h2>
       <div id="formFields"></div>
       <div class="modal-actions">
-        <button id="addField">Add Setting</button>
-        <button id="saveModule">Save</button>
-        <button id="closeModal">Cancel</button>
+        <button id="addField" data-i18n="addSetting">Add Setting</button>
+        <button id="saveModule" data-i18n="save">Save</button>
+        <button id="closeModal" data-i18n="cancel">Cancel</button>
       </div>
     </div>
   </div>
+  <div id="settingsModal" class="modal hidden">
+    <div class="modal-content card-shadow">
+      <h2 data-i18n="settings">Settings</h2>
+      <div class="modal-actions">
+        <button id="closeSettings" data-i18n="close">Close</button>
+      </div>
+    </div>
+  </div>
+  <script src="lang.js"></script>
   <script src="admin.js"></script>
 </body>
 </html>

--- a/public/admin.js
+++ b/public/admin.js
@@ -16,6 +16,20 @@ if (themeToggle) {
   });
 }
 
+const settingsBtn = document.getElementById('settingsBtn');
+if (settingsBtn) {
+  settingsBtn.addEventListener('click', () => {
+    document.getElementById('settingsModal').classList.remove('hidden');
+  });
+}
+
+const closeSettings = document.getElementById('closeSettings');
+if (closeSettings) {
+  closeSettings.addEventListener('click', () => {
+    document.getElementById('settingsModal').classList.add('hidden');
+  });
+}
+
 function createFieldRow(key = '', value = '', allowKey = false) {
   const row = document.createElement('div');
   row.className = 'field-row';
@@ -70,12 +84,15 @@ async function loadModules() {
     card.appendChild(title);
 
     const btn = document.createElement('button');
-    btn.textContent = 'Edit';
+    btn.textContent = t('edit');
+    btn.dataset.i18n = 'edit';
     btn.addEventListener('click', () => openEditor(name));
     card.appendChild(btn);
 
     container.appendChild(card);
   });
+
+  applyTranslations();
 }
 
 document.getElementById('addField').addEventListener('click', () => {

--- a/public/lang.js
+++ b/public/lang.js
@@ -1,0 +1,50 @@
+const translations = {
+  en: {
+    title: "Module Admin",
+    edit: "Edit",
+    addSetting: "Add Setting",
+    save: "Save",
+    cancel: "Cancel",
+    settings: "Settings",
+    close: "Close"
+  },
+  sv: {
+    title: "Moduladministratör",
+    edit: "Redigera",
+    addSetting: "Lägg till inställning",
+    save: "Spara",
+    cancel: "Avbryt",
+    settings: "Inställningar",
+    close: "Stäng"
+  }
+};
+
+let currentLang = localStorage.getItem('lang') || 'en';
+
+function t(key) {
+  return (translations[currentLang] && translations[currentLang][key]) || key;
+}
+
+function applyTranslations() {
+  document.querySelectorAll('[data-i18n]').forEach(el => {
+    const key = el.getAttribute('data-i18n');
+    if (translations[currentLang] && translations[currentLang][key]) {
+      el.textContent = translations[currentLang][key];
+    }
+  });
+}
+
+function setLanguage(lang) {
+  currentLang = lang;
+  localStorage.setItem('lang', lang);
+  applyTranslations();
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const select = document.getElementById('languageSelect');
+  if (select) {
+    select.value = currentLang;
+    select.addEventListener('change', () => setLanguage(select.value));
+  }
+  applyTranslations();
+});


### PR DESCRIPTION
## Summary
- add light/dark theme toggle with language selector and settings button
- introduce translation support and placeholder settings modal
- improve modal sizing and responsive layout with glass styling

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b59c4f8a4883249046e841c69ef5ba