### PR TITLE
Add module update functionality

### DIFF
--- a/public/admin.js
+++ b/public/admin.js
@@ -76,23 +76,37 @@ async function loadModules() {
 
   (config.modules || []).forEach(m => { moduleMap[m.module] = m; });
 
-  modules.forEach(name => {
+  modules.forEach(mod => {
+    const name = mod.name || mod;
     const card = document.createElement('div');
     card.className = 'module-card card-shadow';
     const title = document.createElement('h2');
     title.textContent = name;
     card.appendChild(title);
 
-    const btn = document.createElement('button');
-    btn.textContent = t('edit');
-    btn.dataset.i18n = 'edit';
-    btn.addEventListener('click', () => openEditor(name));
-    card.appendChild(btn);
+    const editBtn = document.createElement('button');
+    editBtn.textContent = t('edit');
+    editBtn.dataset.i18n = 'edit';
+    editBtn.addEventListener('click', () => openEditor(name));
+    card.appendChild(editBtn);
+
+    if (mod.hasUpdate) {
+      const upBtn = document.createElement('button');
+      upBtn.textContent = t('update');
+      upBtn.dataset.i18n = 'update';
+      upBtn.addEventListener('click', () => updateModule(name));
+      card.appendChild(upBtn);
+    }
 
     container.appendChild(card);
   });
 
   applyTranslations();
+}
+
+async function updateModule(name) {
+  await fetch(`/api/modules/${encodeURIComponent(name)}/update`, { method: 'POST' });
+  location.reload();
 }
 
 document.getElementById('addField').addEventListener('click', () => {

--- a/public/lang.js
+++ b/public/lang.js
@@ -6,7 +6,8 @@ const translations = {
     save: "Save",
     cancel: "Cancel",
     settings: "Settings",
-    close: "Close"
+    close: "Close",
+    update: "Update"
   },
   sv: {
     title: "Moduladministratör",
@@ -15,7 +16,8 @@ const translations = {
     save: "Spara",
     cancel: "Avbryt",
     settings: "Inställningar",
-    close: "Stäng"
+    close: "Stäng",
+    update: "Uppdatera"
   }
 };
 


### PR DESCRIPTION
## Summary
- detect pending updates for each module via git
- add API endpoint to update modules and attempt MagicMirror restart
- show update button in admin UI with translations

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --check node_helper.js`
- `node --check public/admin.js`
- `node --check public/lang.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5a3b97440832486bdb47cd61d7d7f