### PR TITLE
Fix module card button layout and style

### DIFF
--- a/public/admin.css
+++ b/public/admin.css
@@ -163,6 +163,27 @@ h1, h2 {
   margin-bottom: 1rem;
 }
 
+.module-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.module-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.module-actions button {
+  margin-top: 0;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  background: var(--card-bg);
+  backdrop-filter: blur(var(--blur));
+  box-shadow: var(--shadow);
+  cursor: pointer;
+}
+
 /* Lists that live inside cards (rounded corners preserved) */
 .list-group-item {
   background: var(--card-bg);

--- a/public/admin.js
+++ b/public/admin.js
@@ -80,22 +80,31 @@ async function loadModules() {
     const name = mod.name || mod;
     const card = document.createElement('div');
     card.className = 'module-card card-shadow';
+
+    const header = document.createElement('div');
+    header.className = 'module-header';
+    card.appendChild(header);
+
     const title = document.createElement('h2');
     title.textContent = name;
-    card.appendChild(title);
+    header.appendChild(title);
+
+    const actions = document.createElement('div');
+    actions.className = 'module-actions';
+    header.appendChild(actions);
 
     const editBtn = document.createElement('button');
     editBtn.textContent = t('edit');
     editBtn.dataset.i18n = 'edit';
     editBtn.addEventListener('click', () => openEditor(name));
-    card.appendChild(editBtn);
+    actions.appendChild(editBtn);
 
     if (mod.hasUpdate) {
       const upBtn = document.createElement('button');
       upBtn.textContent = t('update');
       upBtn.dataset.i18n = 'update';
       upBtn.addEventListener('click', () => updateModule(name));
-      card.appendChild(upBtn);
+      actions.appendChild(upBtn);
     }
 
     container.appendChild(card);


### PR DESCRIPTION
## Summary
- Group module card title and buttons into a header for consistent placement
- Add flexbox styling and rounded button visuals

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68b5a7047f608324a45c118b03143163