### PR TITLE
Place module actions at bottom and delay update refresh

### DIFF
--- a/public/admin.css
+++ b/public/admin.css
@@ -161,16 +161,11 @@ h1, h2 {
 .module-card {
   padding: 1rem;
   margin-bottom: 1rem;
-}
-
-.module-header {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
+  flex-direction: column;
 }
 
-.module-header h2 {
-  flex: 1;
+.module-card h2 {
   margin: 0;
   white-space: nowrap;
   overflow: hidden;
@@ -181,6 +176,7 @@ h1, h2 {
   display: flex;
   gap: 0.5rem;
   flex-shrink: 0;
+  margin-top: auto;
 }
 
 .module-actions button {

--- a/public/admin.js
+++ b/public/admin.js
@@ -81,17 +81,13 @@ async function loadModules() {
     const card = document.createElement('div');
     card.className = 'module-card card-shadow';
 
-    const header = document.createElement('div');
-    header.className = 'module-header';
-    card.appendChild(header);
-
     const title = document.createElement('h2');
     title.textContent = name;
-    header.appendChild(title);
+    card.appendChild(title);
 
     const actions = document.createElement('div');
     actions.className = 'module-actions';
-    header.appendChild(actions);
+    card.appendChild(actions);
 
     const editBtn = document.createElement('button');
     editBtn.textContent = t('edit');
@@ -115,6 +111,7 @@ async function loadModules() {
 
 async function updateModule(name) {
   await fetch(`/api/modules/${encodeURIComponent(name)}/update`, { method: 'POST' });
+  await new Promise(resolve => setTimeout(resolve, 10000));
   location.reload();
 }
 


### PR DESCRIPTION
## Summary
- Position module buttons at the bottom of each card to keep text and actions separate
- Delay page reload by 10 seconds after invoking a module update

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b5ac30c918832488da6043d4454f84