### PR TITLE
fix: ensure bootstrap is loaded before admin script

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -103,8 +103,8 @@
 
   <!-- Scripts (order matches the other page) -->
   <script src="lang.js"></script>
-  <script src="admin.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="admin.js"></script>
 
   <!-- Optional: small helper to set the theme icon on load -->
   <script>


### PR DESCRIPTION
## Summary
- Load Bootstrap bundle before the admin script so button handlers can use Bootstrap components.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b5b57f9a488324abbc9c6c512b786a