### PR TITLE
Fix modal overlay blocking UI interactions

### DIFF
--- a/public/admin.css
+++ b/public/admin.css
@@ -259,18 +259,10 @@ h1, h2 {
 
 /* ======
    MODAL
-   ====== */
-.modal {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.5);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-.modal.hidden {
-  display: none;
-}
+   ======
+   Rely on Bootstrap's modal layout to avoid covering the entire page
+   with a fixed overlay. Only adjust the content box styling here.
+*/
 .modal-content {
   width: 90%;
   max-width: 600px;


### PR DESCRIPTION
## Summary
- remove custom CSS that forced Bootstrap modals to cover the screen

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b5b8641eb88324819337624b72c8c8