### PR TITLE
Fix theme toggle and widen edit fields

### DIFF
--- a/public/admin.css
+++ b/public/admin.css
@@ -278,11 +278,18 @@ h1, h2 {
   display: flex;
   margin-bottom: 0.5rem;
 }
-.field-row input {
+.field-row .field-key {
+  flex: 0 0 30%;
+}
+.field-row .field-value {
   flex: 1;
 }
 .field-row input + input {
   margin-left: 0.5rem;
+}
+
+.modal-dialog {
+  max-width: 700px;
 }
 
 .modal-actions {

--- a/public/admin.html
+++ b/public/admin.html
@@ -106,19 +106,5 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <script src="admin.js"></script>
 
-  <!-- Optional: small helper to set the theme icon on load -->
-  <script>
-    (function () {
-      const html = document.documentElement;
-      const icon = document.getElementById('themeIcon');
-      const setIcon = () => icon && (icon.className = html.getAttribute('data-theme') === 'dark' ? 'bi bi-moon-stars' : 'bi bi-brightness-high');
-      setIcon();
-      document.getElementById('themeToggle')?.addEventListener('click', () => {
-        const next = html.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
-        html.setAttribute('data-theme', next);
-        setIcon();
-      });
-    })();
-  </script>
 </body>
 </html>

--- a/public/admin.js
+++ b/public/admin.js
@@ -7,15 +7,26 @@ let settingsModal;
 document.addEventListener('DOMContentLoaded', () => {
   const root = document.documentElement;
   const themeToggle = document.getElementById('themeToggle');
+  const themeIcon = document.getElementById('themeIcon');
   const savedTheme = localStorage.getItem('theme');
   if (savedTheme) {
     root.setAttribute('data-theme', savedTheme);
   }
+  const setIcon = () => {
+    if (themeIcon) {
+      themeIcon.className =
+        root.getAttribute('data-theme') === 'dark'
+          ? 'bi bi-moon-stars'
+          : 'bi bi-brightness-high';
+    }
+  };
+  setIcon();
   if (themeToggle) {
     themeToggle.addEventListener('click', () => {
       const newTheme = root.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
       root.setAttribute('data-theme', newTheme);
       localStorage.setItem('theme', newTheme);
+      setIcon();
     });
   }
 


### PR DESCRIPTION
## Summary
- ensure theme toggle works and icon updates with current theme
- remove duplicate inline theme script to avoid double toggling
- widen configuration edit fields and modal for better usability

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b5ba0b5a9483249c3757801d03fcd7