### PR TITLE
fix: ensure module names visible in dark mode

### DIFF
--- a/public/admin.css
+++ b/public/admin.css
@@ -170,6 +170,11 @@ h1, h2 {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  color: var(--text);
+}
+
+[data-theme="dark"] .module-card h2 {
+  color: #fff;
 }
 
 .module-actions {


### PR DESCRIPTION
## Summary
- ensure module cards display white titles in dark mode
- review dark/light styles for consistency

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b5bd4762088324893a92a7be3b4f7e