### PR TITLE
Edit module settings in separate rows

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -69,7 +69,8 @@
             <button type="button" class="btn-close" data-bs-dismiss="modal" id="closeModal"></button>
           </div>
           <div class="modal-body">
-            <textarea id="moduleJson" class="form-control" rows="10"></textarea>
+            <div id="moduleForm"></div>
+            <button id="addSetting" class="btn btn-outline-secondary btn-sm mt-2" data-i18n="addSetting">Add Setting</button>
             <div class="d-flex justify-content-end gap-2 mt-3 modal-actions">
               <button id="saveModule" class="btn btn-primary" data-i18n="save">Save</button>
               <button class="btn btn-secondary" data-bs-dismiss="modal" data-i18n="cancel">Cancel</button>


### PR DESCRIPTION
## Summary
- Replace JSON textarea with form rows to edit individual settings
- Always expose module position and allow adding new config keys
- Save changes back to config file

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b5fc2bfdb883249d1306ca8ed50e79