### PR TITLE
feat: add module toggle with restart

### DIFF
--- a/public/admin.css
+++ b/public/admin.css
@@ -409,3 +409,13 @@ button {
     border-radius: 0.5rem;
   }
 }
+
+.status-btn.enabled {
+  background-color: #28a745;
+  color: #fff;
+}
+
+.status-btn.disabled {
+  background-color: #ffc107;
+  color: #000;
+}

--- a/public/admin.js
+++ b/public/admin.js
@@ -140,6 +140,16 @@ async function loadModules() {
     actions.className = 'module-actions';
     card.appendChild(actions);
 
+    const toggleBtn = document.createElement('button');
+    const enabled = !!moduleMap[name];
+    setToggleButton(toggleBtn, enabled);
+    toggleBtn.addEventListener('click', async () => {
+      const res = await fetch(`/api/modules/${encodeURIComponent(name)}/toggle`, { method: 'POST' });
+      const data = await res.json();
+      setToggleButton(toggleBtn, data.enabled);
+    });
+    actions.appendChild(toggleBtn);
+
     const editBtn = document.createElement('button');
     editBtn.textContent = t('edit');
     editBtn.dataset.i18n = 'edit';
@@ -158,6 +168,11 @@ async function loadModules() {
   });
 
   applyTranslations();
+}
+
+function setToggleButton(btn, enabled) {
+  btn.textContent = enabled ? 'enabled' : 'disabled';
+  btn.className = enabled ? 'status-btn enabled' : 'status-btn disabled';
 }
 
 async function updateModule(name) {


### PR DESCRIPTION
## Summary
- allow toggling modules via new /api/modules/:name/toggle endpoint
- add UI toggle button showing enabled/disabled with color cues
- restart MagicMirror after toggling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --check node_helper.js`
- `node --check public/admin.js`


------
https://chatgpt.com/codex/tasks/task_e_68b60c4dd0d48324a310e7e61e96efae